### PR TITLE
Streams are unlocked by default now.

### DIFF
--- a/leaf-frames.dylan
+++ b/leaf-frames.dylan
@@ -245,7 +245,7 @@ define method assemble-frame-into (frame :: <fixed-size-byte-vector-frame>,
 end;
 
 define method as (class == <string>, frame :: <fixed-size-byte-vector-frame>) => (res :: <string>)
-  let out-stream = make(<string-stream>, direction: #"output", stream-lock: #f);
+  let out-stream = make(<string-stream>, direction: #"output");
   block ()
     hexdump(out-stream, frame.data);
     out-stream.stream-contents;
@@ -490,7 +490,7 @@ define constant $empty-raw-frame
   = make(<raw-frame>, data: make(<byte-sequence>, capacity: 0));
 
 define method as (class == <string>, frame :: <raw-frame>) => (res :: <string>)
-  let out-stream = make(<string-stream>, direction: #"output", stream-lock: #f);
+  let out-stream = make(<string-stream>, direction: #"output");
   block ()
     hexdump(out-stream, frame.data);
     out-stream.stream-contents;


### PR DESCRIPTION
As of Open Dylan 2013.2, streams are unlocked by default, so this
explicit disabling of a stream lock is not needed.
