### PR TITLE
Remove source-address, destination-address.

### DIFF
--- a/binary-data.dylan
+++ b/binary-data.dylan
@@ -328,18 +328,6 @@ define open abstract class <unparsed-header-frame>
   (<header-frame>, <unparsed-container-frame>)
 end;
 
-define open generic source-address
-    (frame :: type-union(<raw-frame>, <container-frame>)) => (res);
-
-define open generic source-address-setter
-    (value, frame :: type-union(<raw-frame>, <container-frame>)) => (res);
-
-define open generic destination-address
-    (frame :: type-union(<raw-frame>, <container-frame>)) => (res);
-
-define open generic destination-address-setter
-    (value, frame :: type-union(<raw-frame>, <container-frame>)) => (res);
-
 //can't specify type because unparsed-getter can't return false-or(<frame>)!
 define open generic payload (frame :: <header-frame>) => (payload);
 

--- a/library.dylan
+++ b/library.dylan
@@ -118,8 +118,6 @@ define module binary-data
     parent, parent-setter,
     packet, packet-setter,
     cache,
-    source-address, source-address-setter,
-    destination-address, destination-address-setter,
     payload-type,
     container-frame-size,
     layer-magic,


### PR DESCRIPTION
These aren't needed in binary-data itself.
