### PR TITLE
Documentation fixes

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 import sys, os
+import sphinxcontrib.dylan.themes as dylan_themes
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -25,7 +26,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['dylandomain.dylandomain']
+extensions = ['sphinxcontrib.dylan.domain']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -97,15 +98,15 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'haiku'
+html_theme = dylan_themes.get_html_theme_default()
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = dylan_themes.get_html_theme_options_default()
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [dylan_themes.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/documentation/source/reference.rst
+++ b/documentation/source/reference.rst
@@ -160,6 +160,7 @@ defined (there might be need for other combinations in the future).
    :superclasses: :class:`<leaf-frame>`, :class:`<variable-size-untranslated-frame>`
 
 .. class:: <null-frame>
+
    :description:
 
       A concrete zero size leaf frame without a translation. This frame type 

--- a/documentation/source/reference.rst
+++ b/documentation/source/reference.rst
@@ -163,9 +163,9 @@ defined (there might be need for other combinations in the future).
 
    :description:
 
-      A concrete zero size leaf frame without a translation. This frame type 
-      can be used as one of the types of a variably-typed field to make the 
-      field optional. A field with a type <null-frame> is considered to be 
+      A concrete zero size leaf frame without a translation. This frame type
+      can be used as one of the types of a variably-typed field to make the
+      field optional. A field with a type <null-frame> is considered to be
       missing from the container frame. Conversion of a <null-frame> to string
       or vice versa is not supported (because it wouldn't make much sense).
 
@@ -1064,7 +1064,7 @@ Predefined Leaf Frames
 -------------
 
 The :drm:`<integer>` type in Dylan is represented by only 30
-bits, thus 32 bit frames which should be represented as a 
+bits, thus 32 bit frames which should be represented as a
 :drm:`<number>` require a workaround. The workaround consists of using
 :class:`<fixed-size-byte-vector-frame>` and converting to
 :drm:`<double-float>` values.

--- a/documentation/source/usage.rst
+++ b/documentation/source/usage.rst
@@ -265,12 +265,12 @@ Inheritance: Variably Typed Container Frames
 A container frame can inherit from another container frame that
 already has some fields defined. The
 :class:`<variably-typed-container-frame>` class is used in container
-frames which have the type information encoded in the frame. The 
+frames which have the type information encoded in the frame. The
 layering field (:class:`<layering-field>`) of such container
 frames must be parsed in order to determine the actual type.
 
 Continuing with the ``<ethernet-frame>`` example, consider the `options of an
-IPv4 packet <https://en.wikipedia.org/wiki/IPv4#Options>`__. These share a 
+IPv4 packet <https://en.wikipedia.org/wiki/IPv4#Options>`__. These share a
 common header (``copy-flag`` and ``option-type``), but a concrete option
 might have additional fields. The end of the options list is determined by
 the ``header-length`` field of an IPv4 packet and by the
@@ -325,10 +325,10 @@ Variably-typed
 --------------
 
 Most fields have the same type in all frame instances, i.e. they are
-statically typed. In some cases however, the type of a field can 
+statically typed. In some cases however, the type of a field can
 depend on the value of another field in the same :class:`<container-frame>`.
 Such fields can be defined using :class:`<variably-typed-field>` which does
-not have a static type, but an expression determining the field type for a 
+not have a static type, but an expression determining the field type for a
 concrete frame instance.
 
 This example uses the ``variably-typed field`` syntax. The


### PR DESCRIPTION
This fixes the docs to work with the new ``sphinx-extensions`` setup and to match the rest of the documentation in how that is done (and to use the new theme).

It also fixes a couple of other issues that I noticed while doing the update for ``sphinx-extensions``.