### PR TITLE
Open and export bit and byte frames.

### DIFF
--- a/leaf-frames.dylan
+++ b/leaf-frames.dylan
@@ -113,7 +113,7 @@ define inline method high-level-type (low-level-type == <unsigned-byte>)
 end;
 
 
-define abstract class <unsigned-integer-bit-frame> (<fixed-size-translated-leaf-frame>)
+define open abstract class <unsigned-integer-bit-frame> (<fixed-size-translated-leaf-frame>)
 end;
 
 define macro n-bit-unsigned-integer-definer
@@ -285,11 +285,11 @@ define method \= (frame1 :: <fixed-size-byte-vector-frame>,
   frame1.data = frame2.data
 end method;
 
-define abstract class <big-endian-unsigned-integer-byte-frame> (<fixed-size-translated-leaf-frame>)
+define open abstract class <big-endian-unsigned-integer-byte-frame> (<fixed-size-translated-leaf-frame>)
   //slot data :: <integer>, required-init-keyword: data:;
 end;
 
-define abstract class <little-endian-unsigned-integer-byte-frame> (<fixed-size-translated-leaf-frame>)
+define open abstract class <little-endian-unsigned-integer-byte-frame> (<fixed-size-translated-leaf-frame>)
 end;
 
 define macro n-byte-unsigned-integer-definer

--- a/library.dylan
+++ b/library.dylan
@@ -31,7 +31,9 @@ define module binary-data
 
   export byte-aligned, high-level-type;
 
-  export n-byte-vector-definer, n-bit-unsigned-integer-definer;
+  export n-bit-unsigned-integer-definer, <unsigned-integer-bit-frame>,
+    n-byte-vector-definer, <big-endian-unsigned-integer-byte-frame>,
+    <little-endian-unsigned-integer-byte-frame>;
 
   export hexdump;
 


### PR DESCRIPTION
The following classes are open and exported:
- <unsigned-integer-bit-frame>
- <big-endian-unsigned-integer-byte-frame>
- <little-endian-unsigned-integer-byte-frame>

These classes need to be open and exported in order to
n-bit-unsigned-integer and n-byte-unsigned-integer macros to work.