### PR TITLE
Fix error in field 'url' of package description

### DIFF
--- a/dylan-package.json
+++ b/dylan-package.json
@@ -10,6 +10,6 @@
 	"sphinx-extensions"
     ],
     "license": "MIT",
-    "url": "A DSL for parsing and assembling binary data",
+    "url": "https://github.com/dylan-lang/binary-data",
     "version": "0.1.1"
 }


### PR DESCRIPTION
The field contains the description